### PR TITLE
New autocomplete event

### DIFF
--- a/src/jquery.liveaddress.js
+++ b/src/jquery.liveaddress.js
@@ -2395,9 +2395,9 @@
 
 		AutocompleteUsed: function(event, data)
 		{
-      if (config.debug)
-        console.log("EVENT:", "AutocompleteUsed", "(A suggested address was used from the autocomplete service)", event, data);
-    },
+			if (config.debug)
+				console.log("EVENT:", "AutocompleteUsed", "(A suggested address was used from the autocomplete service)", event, data);
+		},
 
 		AddressChanged: function(event, data)
 		{

--- a/src/jquery.liveaddress.js
+++ b/src/jquery.liveaddress.js
@@ -980,6 +980,7 @@
 				if (domfields['lastline'])
 					$(domfields['lastline']).val(suggestion.city + " " + suggestion.state).change();
 			}
+			trigger("AutocompleteUsed", {address: addr, suggestion: suggestion});
 		}
 
 		// Computes where the little checkmark tag of the UI goes, relative to the boundaries of the last field
@@ -2391,6 +2392,12 @@
 				console.log("EVENT:", "AutocompleteReceived", "(A response has just been received from the autocomplete service)", event, data);
 			ui.showAutocomplete(event, data);
 		},
+
+		AutocompleteUsed: function(event, data)
+		{
+      if (config.debug)
+        console.log("EVENT:", "AutocompleteUsed", "(A suggested address was used from the autocomplete service)", event, data);
+    },
 
 		AddressChanged: function(event, data)
 		{


### PR DESCRIPTION
Adding this event to allow for further customization.  For example, if you wanted to have the address attempt verification after each autocomplete, you can use the event ->
```javascript
liveaddress.on("AutocompleteUsed", function(event, data, previousHandler)
  {
    data.address.verify();
  }
```