### PR TITLE
Remove "off" for bindings based on change of address fields

### DIFF
--- a/src/jquery.liveaddress.js
+++ b/src/jquery.liveaddress.js
@@ -1171,7 +1171,6 @@
 									submitButtons[k].style.color = "black";
 								}
 							}
-							$(doms[prop]).off("change");
 						}
 					}
 					if (doms.address1)


### PR DESCRIPTION
A minor change, to ensure that smartystreets can works with Single Page Apps, in your code, your have an off that is disabling any listener that is listening for the change event of the address fields, but in the other side, your don't have an "on" for event binding on the change.

Some integrations, using third-party frameworks, can crash, due smartystreets is deliberately unbinding everything on the change of these fields.

One example is: https://github.com/frappe/frappe/blob/develop/frappe/public/js/frappe/form/control.js#L329, were the framework expect for on change event, but smartystreets disable it after 2 or 3 changes in the country fields eg:

USA -> Brasil -> Italy will completely disable any hook previously bindend on change of the fields.