### PR TITLE
Fix for setting autocomplete on only the requisite fields, and not al…

### DIFF
--- a/src/jquery.liveaddress.js
+++ b/src/jquery.liveaddress.js
@@ -1216,10 +1216,41 @@
 		function disableBrowserAutofill(dom) {
 			//Does not disable autofill if config.autocomplete is disabled
 			if (config.autocomplete > 0) {
-				for (var i = 0; i < dom.getElementsByTagName("input").length; i++) {
-					dom.getElementsByTagName("input")[i].autocomplete = "smartystreets";
+				const uniqueElementIds = getUniqueAddressInputIds();
+				for (var i = 0; i < uniqueElementIds.length; i++) {
+					const id = uniqueElementIds[i];
+					const elem = dom.querySelector(normalizeId(id));
+					if (elem) {
+						elem.autocomplete = "smartystreets";
+					}
 				}
 			}
+		}
+
+		function normalizeId(id) {
+			return '#' + id.replace('#', '');
+		}
+
+		function getUniqueAddressInputIds() {
+			const uniqueElementIds = [];
+
+			config.addresses.forEach(address => {
+				// These might be strings, or maybe dom input references
+				const objs = Object.keys(address).map(key => address[key]);
+				objs.forEach((obj) => {
+					let id;
+					if (typeof obj === 'string') {
+						id = obj;
+					} else {
+						id = obj.id;
+					}
+					if (!uniqueElementIds.includes(id)) {
+						uniqueElementIds.push(id);
+					}
+				});
+			});
+
+			return uniqueElementIds;
 		}
 
 		function addDefaultToStateDropdown(dom) {


### PR DESCRIPTION
Imagine you're filling out a registration form where SmartyStreets is used. All of your autocomplete fields are set to "smartystreets": your first name, last name, address... all the fields.

You fill out the form, no problems, Smartystreets works, yay!

Now you come back to that same form, and update your information, Chrome is helpful, throwing up the autofill feature... and you're like "Heck yeah, fill those fields for me Chrome!"

But, since every input has autocomplete="smartystreets"... every single input on the page gets your first name... and you're like "Why, Smartystreets, why?"

I'm submitting this fix so that Smartystreets will mark autocomplete="smartystreets" on only the requisite ADDRESS fields that you specify in config.addresses, and not all inputs, which can cause autocomplete to put undesired data into fields.

Thanks!